### PR TITLE
fix: Ignore .git* files when loading helpers.

### DIFF
--- a/src/view/compiler.js
+++ b/src/view/compiler.js
@@ -37,7 +37,7 @@ class HandlebarsCompiler {
     helpersPaths.forEach(helpersPath => {
       if (Fs.existsSync(helpersPath)) {
         Fs.readdirSync(helpersPath).forEach(file => {
-          if (!file.startsWith('.git')) {
+          if (!file.startsWith('.')) {
             this.registerHelper(helpersPath, file)
           }
         })
@@ -54,7 +54,7 @@ class HandlebarsCompiler {
 
       if (typeof helper === 'function') {
         this._engine.registerHelper(name, helper)
-        Logger.info('Registered helper function:  ' + Path.basename(file))
+        Logger.debug('Registered helper function:  ' + Path.basename(file))
       }
       else {
 	      Logger.warn(`Helper file '${Path.basename(file)}' is not a function, it's a ${typeof helper}`)

--- a/src/view/compiler.js
+++ b/src/view/compiler.js
@@ -37,7 +37,9 @@ class HandlebarsCompiler {
     helpersPaths.forEach(helpersPath => {
       if (Fs.existsSync(helpersPath)) {
         Fs.readdirSync(helpersPath).forEach(file => {
-          this.registerHelper(helpersPath, file)
+          if (!file.startsWith('.git')) {
+            this.registerHelper(helpersPath, file)
+          }
         })
       }
     })
@@ -52,6 +54,10 @@ class HandlebarsCompiler {
 
       if (typeof helper === 'function') {
         this._engine.registerHelper(name, helper)
+        Logger.info('Registered helper function:  ' + Path.basename(file))
+      }
+      else {
+	      Logger.warn(`Helper file '${Path.basename(file)}' is not a function, it's a ${typeof helper}`)
       }
     } catch (err) {
       Logger.warn(`WARNING: failed to load helper ${file}: ${err.message}`)


### PR DESCRIPTION
* When loading helpers, ignore all file names that start with .git.  This prevents attempted loading of .gitignore, and others.  These would fall out later anyway, because "typeof helper != function".  But makes sense to just skip them initially.
* Added an "else" statement when registering helpers.  If typeof helper is not a function, warn about this, and log the actual type found.
* Info message, showing when helpers are loaded successfully.  I found this helpful, since I wasn't confident my custom helper actually was loaded.