### PR TITLE
Add support for hosting web fonts.

### DIFF
--- a/src/foundation/http/bootstrap/serve-assets.js
+++ b/src/foundation/http/bootstrap/serve-assets.js
@@ -50,6 +50,17 @@ class LoadRoutes {
       },
       {
         method: 'GET',
+        path: '/fonts/{path*}',
+        config: {
+          handler: { directory: { path: this.resolveAsset('fonts') } },
+          cache: {
+            expiresIn: this.expiresIn,
+            privacy: 'private'
+          }
+        }
+      },
+      {
+        method: 'GET',
         path: '/favicon.ico',
         handler: { file: { path: this.resolveAsset('favicon.ico') } }
       }


### PR DESCRIPTION
If the Supercharge user wants to host their own fonts (TTF, WOFF), this code allows for that.  

Just create a sub folder under public named "fonts".  Then those font assets will be shared and available to the website.  You can load your fonts from your CSS.