### PR TITLE
Update kernel.js > fetch host from configuration.

### DIFF
--- a/src/foundation/http/kernel.js
+++ b/src/foundation/http/kernel.js
@@ -40,7 +40,7 @@ class HttpKernel {
    */
   createServer () {
     return new Hapi.Server({
-      host: 'localhost',
+      host: Config.get('app.host'),
       port: Config.get('app.port'),
       router: {
         stripTrailingSlash: true


### PR DESCRIPTION
This is directly related to the supercharge pull request below:
https://github.com/superchargejs/supercharge/pull/2

Instead of hard-coding the server host to 'localhost', fetch from the app.js configuration.